### PR TITLE
IRB committers

### DIFF
--- a/source/timetable.html.haml
+++ b/source/timetable.html.haml
@@ -41,7 +41,7 @@
     %td.p-time-table__td 14:30 - 15:00
     %td.p-time-table__td 招待講演
     %td.p-time-table__td.is-text-left
-      irbコミッター
+      IRBコミッターズ
       =link_to "@hasumikin", "https://twitter.com/hasumikin"
       =link_to "@tompng", "https://twitter.com/tompng"
       =link_to "@ima1zumi", "https://twitter.com/ima1zumi"


### PR DESCRIPTION
"ruby" vs "Ruby" と一緒で、どちらかといえば"irb" はコマンド名で、プロダクト名は "IRB" なのかな、と。
https://github.com/ruby/irb/blob/master/README.md

それから、3人いるので "committers" ではあるんだけど、「コミッターズ」が日本語の字面的にはあんまりカッコ良くもないので、「IRBチーム」とかそういう何かでもいいかもしれなくて、そのあたりは本人たちの希望などあれば、というところなんだけど、本人たちに聞いたりしてるとますます出すのが遅くなりそうだし、とりあえずいったんこれでどうでしょう？
(と、言いつつ、一応メンションはしておきます @hasumikin @tompng @ima1zumi )