### PR TITLE
Add link to the after party

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -47,7 +47,7 @@ title: 大江戸Ruby会議10
     %p 花やしき
     =link_to "GoogleMap", "https://goo.gl/maps/qixcKYyS2YWKWskb6", class:"c-link--map"
   .p-after-party__block
-    =link_to "懇親会チケットを購入する", "#", class:"c-button--submit"
+    =link_to "懇親会チケットを購入する", "https://asakusarb.doorkeeper.jp/events/164153", target: "_blank", rel: "noopener", class:"c-button--submit"
   .p-after-party__img--left
   .p-after-party__img--right
 


### PR DESCRIPTION
https://asakusarb.doorkeeper.jp/events/164153 ができていたので、そちらへのリンクを追加しています。